### PR TITLE
moving grisp_tools into dependency section

### DIFF
--- a/myapp/rebar.config
+++ b/myapp/rebar.config
@@ -1,13 +1,13 @@
 {deps , [
   {grisp, {git, "https://github.com/pedroAkos/grisp.git", {branch, "master"}}},
-  {epmd, {git, "https://github.com/erlang/epmd", {ref, "4d1a59"}}}
+  {epmd, {git, "https://github.com/erlang/epmd", {ref, "4d1a59"}}},
+  {grisp_tools , {git , " https://github.com/grisp/grisp_tools" , {branch , "master"}}}
 ]}.
 %{ deps , [
 %    {grisp , {git , "https://github.com/grisp/grisp.git" , {branch , "master"}}}
 %]}.
 
 { plugins , [
-    {grisp_tools , {git , " https://github.com/grisp/grisp_tools" , {branch , "master"}}},
     {rebar3_grisp , {git , "https://github.com/grisp/rebar3_grisp.git" , {branch , "master"}}}
 ]}.
 


### PR DESCRIPTION
Since the `grisp_tools` repository is not a rebar3 plugin, the build process for `myapp` will ignore it and it will not be included in the deployable release.